### PR TITLE
Change to throw exception, and add test

### DIFF
--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -376,7 +376,7 @@ public final class AmqpsIotHubConnection extends BaseHandler
                 // If proton failed sending, release dlv object. Otherwise release it when received a disposition frame from proton.
                 sender.advance();
                 dlv.free();
-                deliveryHash = -1;
+                throw e;
             }
         }
 

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -274,7 +274,7 @@ public final class AmqpsIotHubConnection extends BaseHandler
         // specified in config to be used for the communication with IoTHub.]
         this.sasToken = new IotHubSasToken(this.config, System.currentTimeMillis() / 1000L +
                 this.config.getTokenValidSecs() + 1L).toString();
-				
+
         logger.LogInfo("SAS Token is created successfully, method name is %s ", logger.getMethodName());
 
         if (this.reactor == null)
@@ -355,30 +355,30 @@ public final class AmqpsIotHubConnection extends BaseHandler
             }
             // Codes_SRS_AMQPSIOTHUBCONNECTION_15_017: [The function shall set the delivery tag for the sender.]
             byte[] tag = String.valueOf(this. nextTag++).getBytes();
-	    Delivery dlv = sender.delivery(tag);
-	    try
-	    {
+            Delivery dlv = sender.delivery(tag);
+            try
+            {
 
-		logger.LogInfo("Attempting to send the message using the sender link, method name is %s ", logger.getMethodName());
-		// Codes_SRS_AMQPSIOTHUBCONNECTION_15_018: [The function shall attempt to send the message using the sender link.]
-		sender.send(msgData, 0, length);
-            
-		logger.LogInfo("Advancing the sender link, method name is %s ", logger.getMethodName());
-		// Codes_SRS_AMQPSIOTHUBCONNECTION_15_019: [The function shall advance the sender link.]
-		sender.advance();
+                logger.LogInfo("Attempting to send the message using the sender link, method name is %s ", logger.getMethodName());
+                // Codes_SRS_AMQPSIOTHUBCONNECTION_15_018: [The function shall attempt to send the message using the sender link.]
+                sender.send(msgData, 0, length);
 
-		// Codes_SRS_AMQPSIOTHUBCONNECTION_15_020: [The function shall set the delivery hash to the value returned by the sender link.]
-		deliveryHash = dlv.hashCode();
-		logger.LogInfo("Delivery hash returned by the sender link %s, method name is %s ", deliveryHash, logger.getMethodName());
-	    }
-	    catch (Exception e)
-	    {
-		// If proton failed sending, release dlv object. Otherwise release it when received a disposition frame from proton.
-		sender.advance();
-		dlv.free();
-		deliveryHash = -1;
-	    }
-	}
+                logger.LogInfo("Advancing the sender link, method name is %s ", logger.getMethodName());
+                // Codes_SRS_AMQPSIOTHUBCONNECTION_15_019: [The function shall advance the sender link.]
+                sender.advance();
+
+                // Codes_SRS_AMQPSIOTHUBCONNECTION_15_020: [The function shall set the delivery hash to the value returned by the sender link.]
+                deliveryHash = dlv.hashCode();
+                logger.LogInfo("Delivery hash returned by the sender link %s, method name is %s ", deliveryHash, logger.getMethodName());
+            }
+            catch (Exception e)
+            {
+                // If proton failed sending, release dlv object. Otherwise release it when received a disposition frame from proton.
+                sender.advance();
+                dlv.free();
+                deliveryHash = -1;
+            }
+        }
 
         // Codes_SRS_AMQPSIOTHUBCONNECTION_15_021: [The function shall return the delivery hash.]
         return deliveryHash;
@@ -605,8 +605,8 @@ public final class AmqpsIotHubConnection extends BaseHandler
                 {
                     listener.messageSent(d.hashCode(), state);
                 }
-		// release the delivery object which created in sendMessage().
-		d.free();
+                // release the delivery object which created in sendMessage().
+                d.free();
             }
         }
         logger.LogDebug("Exited from method %s", logger.getMethodName());
@@ -911,7 +911,7 @@ public final class AmqpsIotHubConnection extends BaseHandler
 
         return derPath + ".pem" ;
     }
-    
+
     /**
      * Class which runs the reactor.
      */
@@ -932,4 +932,3 @@ public final class AmqpsIotHubConnection extends BaseHandler
         }
     }
 }
-

--- a/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
+++ b/device/iot-device-client/src/main/java/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnection.java
@@ -376,7 +376,7 @@ public final class AmqpsIotHubConnection extends BaseHandler
                 // If proton failed sending, release dlv object. Otherwise release it when received a disposition frame from proton.
                 sender.advance();
                 dlv.free();
-                throw e;
+                deliveryHash = -1;
             }
         }
 

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -665,6 +665,31 @@ public class AmqpsIotHubConnectionTest {
         };
     }
 
+    @Test(expected = Exception.class)
+    public void sendMessageThrowExceptionWithAdvanceAndFree() throws IOException
+    {
+      baseExpectations();
+
+      new Expectations() {
+          {
+              mockSender.send((byte[]) any, anyInt, anyInt);
+              result = new IOException();
+              mockSender.advance();
+              times = 1;
+              mockDelivery.free();
+              times = 1;
+          }
+      };
+
+      final AmqpsIotHubConnection connection = new AmqpsIotHubConnection(mockConfig, false);
+
+      Deencapsulation.setField(connection, "state", State.OPEN);
+      Deencapsulation.setField(connection, "linkCredit", 100);
+      Deencapsulation.setField(connection, "sender", mockSender);
+
+      connection.sendMessage(mockProtonMessage);
+    }
+
     // Tests_SRS_AMQPSIOTHUBCONNECTION_15_022: [If the AMQPS Connection is closed, the function shall return false.]
     @Test
     public void sendMessageReturnsFalseIfConnectionIsClosed() throws IOException

--- a/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
+++ b/device/iot-device-client/src/test/java/tests/unit/com/microsoft/azure/sdk/iot/device/transport/amqps/AmqpsIotHubConnectionTest.java
@@ -665,7 +665,7 @@ public class AmqpsIotHubConnectionTest {
         };
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void sendMessageThrowExceptionWithAdvanceAndFree() throws IOException
     {
       baseExpectations();
@@ -687,7 +687,10 @@ public class AmqpsIotHubConnectionTest {
       Deencapsulation.setField(connection, "linkCredit", 100);
       Deencapsulation.setField(connection, "sender", mockSender);
 
-      connection.sendMessage(mockProtonMessage);
+      Integer expectedResult = -1;
+      Integer actualResult = connection.sendMessage(mockProtonMessage);
+
+      assertEquals(expectedResult, actualResult);
     }
 
     // Tests_SRS_AMQPSIOTHUBCONNECTION_15_022: [If the AMQPS Connection is closed, the function shall return false.]


### PR DESCRIPTION
Hi @hiro4kuribaya4 .

This PR includes 3 commits.

* Fix code indents.
* Fix error handling when catch the exception 
  sendMessage method should return -1 only if it is not prepared (State.CLOSED or\ linkCredit <= 0). 
  So in this case, it should throw exception instead of return -1.
* Add test code for above code.